### PR TITLE
Fix HTML errors and warnings

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,8 +9,8 @@
                 <span class="icon-bar"></span>
                 </button>
             <a class="navbar-brand logo-nav" href="https://www.verovio.org/index.xhtml">
-                <img alt="Verovio logo" src="{{ site.baseurl }}/assets/images/verovio-fadded-50.png" /
-            ></a>
+                <img alt="Verovio logo" src="{{ site.baseurl }}/assets/images/verovio-fadded-50.png" />
+            </a>
         </div>
 
         <!-- Collect the nav links, forms, and other content for toggling -->

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,9 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
                 </button>
-            <a class="navbar-brand logo-nav" href="https://www.verovio.org/index.xhtml"><img src="{{ site.baseurl }}/assets/images/verovio-fadded-50.png" /></a>
+            <a class="navbar-brand logo-nav" href="https://www.verovio.org/index.xhtml">
+                <img alt="Verovio logo" src="{{ site.baseurl }}/assets/images/verovio-fadded-50.png" /
+            ></a>
         </div>
 
         <!-- Collect the nav links, forms, and other content for toggling -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,6 @@
 <html lang="en" xml:lang="en" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <meta charset="utf-8" />
-        <title>{{ page.title }}</title>
         <link rel="icon" type="image/x-icon" href="{{ site.baseurl }}/favicon.ico" />
         <link rel="apple-touch-icon" href="{{ site.baseurl }}/assets/images/verovio-logo-big.png"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" /><!-- Latest compiled and minified CSS -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,8 +18,8 @@
 
         <link rel="stylesheet" href="{{ site.baseurl }}/css/verovio-site.css" />
 
-        <script src="{{ site.baseurl }}/assets/javascript/jquery-3.6.0.min.js" type="text/javascript" ></script>
-        <script src="{{ site.baseurl }}/assets/javascript/bootstrap.min.js" type="text/javascript" ></script>
+        <script src="{{ site.baseurl }}/assets/javascript/jquery-3.6.0.min.js"></script>
+        <script src="{{ site.baseurl }}/assets/javascript/bootstrap.min.js"></script>
 
         {% seo %}
     </head>
@@ -43,7 +43,7 @@
             </p>
         </footer>
 
-        <script type="text/javascript">
+        <script>
         //<![CDATA[
             $(document).ready(function() {
 

--- a/verovio-theme.gemspec
+++ b/verovio-theme.gemspec
@@ -2,9 +2,9 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "verovio-theme"
-  spec.version       = "0.1.17"
-  spec.authors       = ["Laurent Pugin", "Andrew Hankinson"]
-  spec.email         = ["laurent.pugin@rism.digital", "andrew.hankinson@rism.digital"]
+  spec.version       = "0.1.18"
+  spec.authors       = ["Laurent Pugin", "Andrew Hankinson", "Klaus Rettinghaus"]
+  spec.email         = ["laurent.pugin@rism.digital", "andrew.hankinson@rism.digital", "klaus.rettinghaus@enote.com"]
 
   spec.summary       = "Shared theme for Verovio websites."
   spec.homepage      = "https://www.vervio.org"


### PR DESCRIPTION
This PR fixes some HTML errors and warnings:
* remove `title` tag, because `jekyll-seo-tag` creates another one
* remove unneeded `type` attribute on `script` tag
* add a needed alt attribute to `img` tag